### PR TITLE
Added option to append actionButton to custom elt

### DIFF
--- a/www/main.js
+++ b/www/main.js
@@ -129,8 +129,9 @@ function wrapConsole() {
 
 /******************************************************************************/
 
-function createActionButton(title, callback) {
-  var buttons = document.getElementById('buttons');
+function createActionButton(title, callback, appendTo) {
+  appendTo = appendTo ? appendTo : 'buttons';
+  var buttons = document.getElementById(appendTo);
   var div = document.createElement('div');
   var button = document.createElement('a');
   button.textContent = title;


### PR DESCRIPTION
Optional parameter to createActionButton specifies an element of the
document to append it to. Needed for porting manual tests so that we can
group test buttons logically on the page with headings etc. Defaults to buttons div as
before.
