### PR TITLE
Improvement to css

### DIFF
--- a/www/assets/main.css
+++ b/www/assets/main.css
@@ -18,7 +18,7 @@ html, body {
   z-index: 1000;
 
   background-color: #75B2F0;
-  font-size: 25px;
+  font-size: 20px;
   text-align: center;
   font-weight: bold;
 }
@@ -44,7 +44,7 @@ html, body {
 }
 
 #log.expanded {
-  height: 40%;
+  height: 20%;
 }
 
 #log--title {
@@ -81,7 +81,6 @@ html, body {
 .log--content--line--error {
   background-color: #FFA6A6;
 }
-
 #info{
   background:#ffa;
   border: 1px solid #ffd324;


### PR DESCRIPTION
Changed log.expanded to 20% instead of 40%, because it popup really big,
and it becomes into an annoyance. The space is minimum, setting it at
20% it looks nice and functional.

The title for plugins like network-information and file-transfer, the
title is too big that it requires a second line to show the title.

![longtext](https://cloud.githubusercontent.com/assets/6596402/3619156/a088aa06-0df1-11e4-9b51-dda259232fb6.png)
