### PR TITLE
CB-7459 Add header to show number of enabled plugin tests

### DIFF
--- a/www/assets/main.css
+++ b/www/assets/main.css
@@ -123,11 +123,10 @@ html, body {
 }
 
 #test-enablers-container {
-  margin: 10px 0px;
+  margin: 10px 5px;
 }
 
 #test-expander {
-  margin: 5px;
   text-decoration: underline;
 }
 


### PR DESCRIPTION
It is not obvious if all/how many plugin tests are being run, given that:
- Individual plugin tests can be enabled/disabled by the user
- The enabled settings are remembered across app runs (even if the user forgets)
- The UI widgets to enable/disable individual plugins is hidden in a collapsed
 section by default, so are not visible

To aid the user, a header has been added to explicitly show the total number of
tests, and how many are enabled (e.g. "All" vs. "N/M").