### PR TITLE
CB-8295 Enable CSP for mobile spec

### DIFF
--- a/www/assets/index.html
+++ b/www/assets/index.html
@@ -21,6 +21,15 @@
 -->
 <html>
   <head>
+    <!--
+      Inject CSP
+
+      If not hosted in mobilespec, the injection script will likely not
+      exist.  It would be up to the hosting app to provide the named
+      script to setup CSP as desired.
+    -->
+    <script type="text/javascript" src="../csp-incl.js"></script>
+
     <title>Cordova tests</title>
     <meta charset="utf-8" />
     <meta name="format-detection" content="telephone=no" />
@@ -37,6 +46,7 @@
     <script type="text/javascript" src="../cordova.js"></script>
 
     <!-- App scripts -->
+    <script type="text/javascript" src="main-bootstrap.js"></script>
   </head>
 
   <body>
@@ -49,10 +59,5 @@
       <div id='log--title'>Log</div>
       <div id='log--content'></div>
     </div>
-    <script>
-      document.addEventListener("deviceready", function() {
-        cordova.require('org.apache.cordova.test-framework.main').init();
-      });
-    </script>
   </body>
 </html>

--- a/www/assets/main-bootstrap.js
+++ b/www/assets/main-bootstrap.js
@@ -1,0 +1,26 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+'use strict';
+
+document.addEventListener("deviceready", function() {
+  cordova.require('org.apache.cordova.test-framework.main').init();
+});


### PR DESCRIPTION
- Uses a javascript include file (provided by mobile spec app) to document.write a CSP tag on page
- If hosted outside of mobile spec, that app must provide similar injection script
- Change index page to remove inline script (to comply with CSP)

Relates to apache/cordova-mobile-spec#115