### PR TITLE
CB-8973: Changed the functionality of making the log appear and disappear

### DIFF
--- a/www/assets/main.css
+++ b/www/assets/main.css
@@ -64,7 +64,11 @@ html, body {
   transition: 0.25s ease;
 }
 
-#log.expanded {
+body.expanded-log #middle {
+  margin-bottom: 40%;
+}
+
+body.expanded-log #log {
   height: 40%;
 }
 

--- a/www/main.js
+++ b/www/main.js
@@ -70,18 +70,22 @@ function setTitle(title) {
 
 function setLogVisibility(visible) {
   if (visible) {
-    document.getElementById('log').classList.add('expanded');
+    document.querySelector('body').classList.add('expanded-log');
   } else {
-    document.getElementById('log').classList.remove('expanded');
+    document.querySelector('body').classList.add('expanded-log');
   }
 }
 
+function getLogVisibility() {
+  var e = document.querySelector('body');
+  return e.classList.contains('expanded-log');
+}
+
 function toggleLogVisibility() {
-  var log = document.getElementById('log');
-  if (log.classList.contains('expanded')) {
-    log.classList.remove('expanded');
+  if (getLogVisibility()) {
+    setLogVisibility(false);
   } else {
-    log.classList.add('expanded');
+    setLogVisibility(true);
   }
 }
 


### PR DESCRIPTION
When the log appears, it appears over the "content" area, which means (for example) on the Manual Tests page, some tests are impossible to see.  This change alters the log show/hide implementation, such that instead of modifying the #log class list, it modifies the body class list, and the #middle and #log elements adjust their appearances based on having body.expanded-log selector.