### PR TITLE
CB-10636 Add JSHint for plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # OS X
 .DS_Store
+
+node_modules

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,2 @@
+www/assets/jasmine-2.2.0
+www/assets/topcoat-0.7.5

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,18 @@
+{
+    "browser": true
+  , "devel": true
+  , "bitwise": true
+  , "undef": true
+  , "trailing": true
+  , "quotmark": false
+  , "indent": 4
+  , "unused": "vars"
+  , "latedef": "nofunc"
+  , "globals": {
+        "module": false,
+        "exports": false,
+        "require": false,
+        "cordova": true,
+        "jasmineRequire": false
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+sudo: false
+node_js:
+  - "4.2"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 #
 -->
 
+[![Build Status](https://travis-ci.org/apache/cordova-plugin-test-framework.svg?branch=master)](https://travis-ci.org/apache/cordova-plugin-test-framework)
+
 # Cordova Plugin Test Framework
 
 The `cordova-plugin-test-framework` plugin does two things:

--- a/package.json
+++ b/package.json
@@ -15,6 +15,13 @@
     "test",
     "ecosystem:cordova"
   ],
+  "scripts": {
+    "test": "npm run jshint",
+    "jshint": "jshint www"
+  },
   "author": "Apache Software Foundation",
-  "license": "Apache 2.0"
+  "license": "Apache 2.0",
+  "devDependencies": {
+    "jshint": "^2.6.0"
+  }
 }

--- a/www/assets/jasmine-medic.js
+++ b/www/assets/jasmine-medic.js
@@ -19,6 +19,8 @@
  *
 */
 
+/* global device */
+
 jasmineRequire.medic = function(j$) {
   j$.MedicReporter = jasmineRequire.MedicReporter(j$);
 };
@@ -29,34 +31,30 @@ jasmineRequire.MedicReporter = function(j$) {
     elapsed: function() { return 0; }
   };
 
+  var platformMap = {
+    'ipod touch':'ios',
+    'iphone':'ios'
+  };
+
   function MedicReporter(options) {
-    var env = options.env || {},
-    logoptions = options.log || { logurl: 'http://127.0.0.1:5984/' }, // TODO: http://localhost:6800
-    getContainer = options.getContainer,
-    createElement = options.createElement,
-    createTextNode = options.createTextNode,
-    onRaiseExceptionsClick = options.onRaiseExceptionsClick || function() {},
+    var logoptions = options.log || { logurl: 'http://127.0.0.1:5984/' }, // TODO: http://localhost:6800
     timer = options.timer || noopTimer,
     results = [],
     specsExecuted = 0,
     failureCount = 0,
-    pendingSpecCount = 0,
-    symbols;
+    pendingSpecCount = 0;
 
 
     var serverurl = logoptions.logurl;
 
     this.initialize = function() {
-    }
+    };
 
     var totalSpecsDefined;
     this.jasmineStarted = function(options) {
       totalSpecsDefined = options.totalSpecsDefined || 0;
       timer.start();
     };
-
-    var topResults = new j$.ResultsNode({}, "", null),
-    currentParent = topResults;
 
     this.suiteStarted = function(result) {
     };
@@ -69,7 +67,6 @@ jasmineRequire.MedicReporter = function(j$) {
       // Start timing this spec
     };
 
-    var failures = [];
     this.specDone = function(result) {
       if (result.status != "disabled") {
         specsExecuted++;
@@ -83,10 +80,10 @@ jasmineRequire.MedicReporter = function(j$) {
       }
     };
 
-    buildResults = function(){
+    var buildResults = function(){
       var json ={specs:specsExecuted, failures:failureCount, results: results};
       return json;
-    }
+    };
 
     this.jasmineDone = function() {
       var p = 'Desktop';
@@ -109,20 +106,6 @@ jasmineRequire.MedicReporter = function(j$) {
 
     };
 
-
-    logresult = function(){
-      if(failureCount>0 ) {
-        console.log('[[[ TEST OK ]]]');
-      } else {
-        console.log('[[[ TEST FAILED ]]]');
-      }
-      logfinished();
-    };
-
-    var logfinished = function(){
-      console.log('>>> DONE <<<');
-    };
-
     this.postTests = function(json) {
       console.log('posting tests');
 
@@ -130,25 +113,11 @@ jasmineRequire.MedicReporter = function(j$) {
       var doc_id = [options.sha, json.version, json.model].map(encodeURIComponent).join('__');
       var doc_url = serverurl + '/mobilespec_results/' + doc_id;
       xhr.open("PUT", doc_url, true);
-      xhr.setRequestHeader("Content-Type","application/json")
+      xhr.setRequestHeader("Content-Type","application/json");
       xhr.send(JSON.stringify(json));
-    }
+    };
     return this;
   }
-
-   /**
-   * Calculate elapsed time, in Seconds.
-   * @param startMs Start time in Milliseconds
-   * @param finishMs Finish time in Milliseconds
-   * @return Elapsed time in Seconds */
-  function elapsedSec(startMs, finishMs) {
-    return (finishMs - startMs) / 1000;
-  }
-
-  var platformMap = {
-    'ipod touch':'ios',
-    'iphone':'ios'
-  };
 
   return MedicReporter;
 };

--- a/www/assets/main-bootstrap.js
+++ b/www/assets/main-bootstrap.js
@@ -19,8 +19,8 @@
  *
 */
 
-'use strict';
-
 document.addEventListener("deviceready", function() {
+  'use strict';
+
   cordova.require('cordova-plugin-test-framework.main').init();
 });

--- a/www/jasmine_helpers.js
+++ b/www/jasmine_helpers.js
@@ -19,6 +19,7 @@
  *
 */
 
+/* jshint -W097 */
 'use strict';
 
 exports.setUpJasmine = function() {
@@ -48,7 +49,7 @@ exports.setUpJasmine = function() {
     };
 
     return jasmineInterface;
-}
+};
 
 function addJasmineReporters(jasmineInterface, jasmineEnv) {
     jasmineInterface.jsApiReporter = new jasmineInterface.jasmine.JsApiReporter({ timer: new jasmineInterface.jasmine.Timer() });

--- a/www/main.js
+++ b/www/main.js
@@ -19,6 +19,8 @@
  *
 */
 
+/* global WinJS */
+/* jshint -W097 */
 'use strict';
 
 var LOG_HEADER_HEIGHT = 20,
@@ -239,7 +241,7 @@ function createEnablerList() {
 
     barItem.appendChild(link);
     checkButtonBar.appendChild(barItem);
-  };
+  }
   createSelectToggleButton('Check all', true);
   createSelectToggleButton('Uncheck all', false);
   enablerList.appendChild(checkButtonBar);

--- a/www/medic.js
+++ b/www/medic.js
@@ -19,6 +19,7 @@
  *
 */
 
+/* jshint -W097 */
 'use strict';
 
 exports.logurl = 'http://127.0.0.1:7800';
@@ -59,4 +60,4 @@ exports.load = function (callback) {
   setTimeout(function () {
       callback();
   }, 0);
-}
+};

--- a/www/tests.js
+++ b/www/tests.js
@@ -19,6 +19,8 @@
  *
 */
 
+/* jshint jasmine: true */
+/* jshint -W097 */
 'use strict';
 
 exports.tests = Object.create(null);
@@ -44,7 +46,8 @@ function TestModule(api) {
 }
 
 function getTestsObject(api) {
-  return exports.tests[api] = exports.tests[api] || new TestModule(api);
+  exports.tests[api] = exports.tests[api] || new TestModule(api);
+  return exports.tests[api];
 }
 
 function requireAllTestModules() {
@@ -129,4 +132,4 @@ exports.defineManualTests = function(contentEl, beforeEach, createActionButton) 
 
 exports.init = function() {
   requireAllTestModules();
-}
+};


### PR DESCRIPTION
[Jira issue](https://issues.apache.org/jira/browse/CB-10636)

```javascript
/* jshint -W097 */
 'use strict';
```
Ignoring ` Use the function form of 'use strict'` error because Cordova wraps the plugin `js-module`'s as functions.