### PR TITLE
Fixing a few markdown rendering items

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Tests run directly inside existing cordova projects, so you can rapidly switch b
 
 
 <a name="interface" />
+
 ## Writing Plugin Tests
 
 ### Where do tests live?
@@ -117,11 +118,13 @@ Note: Your tests will automatically be labeled with your plugin id, so do not pr
 
 
 <a name="example">
+
 ### Example
 
 See: [`cordova-plugin-device` tests](https://github.com/apache/cordova-plugin-device/blob/master/tests/tests.js).
 
 <a name="harness" />
+
 ## Running Plugin Tests
 
 1. Use your existing cordova app, or create a new one.


### PR DESCRIPTION
A few headings didn't have white space above them (due to the anchor tags).  Just added the white space so the file renders correctly

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
