### PR TITLE
[leftover branch] Revert "CB-8683 changed plugin-id to pacakge-name"

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.2-dev",
   "description": "Cordova Test Framework Plugin",
   "cordova": {
-    "id": "cordova-plugin-test-framework",
+    "id": "org.apache.cordova.test-framework",
     "platforms": []
   },
   "repository": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    id="cordova-plugin-test-framework"
+    id="org.apache.cordova.test-framework"
     version="0.0.2-dev">
     <name>Test Framework</name>
     <description>Cordova Test Framework Plugin</description>

--- a/www/assets/main-bootstrap.js
+++ b/www/assets/main-bootstrap.js
@@ -22,5 +22,5 @@
 'use strict';
 
 document.addEventListener("deviceready", function() {
-  cordova.require('cordova-plugin-test-framework.main').init();
+  cordova.require('org.apache.cordova.test-framework.main').init();
 });

--- a/www/jasmine_helpers.js
+++ b/www/jasmine_helpers.js
@@ -66,7 +66,7 @@ function addJasmineReporters(jasmineInterface, jasmineEnv) {
     jasmineInterface.htmlReporter.initialize();
     jasmineEnv.addReporter(jasmineInterface.htmlReporter);
 
-    var medic = require('cordova-plugin-test-framework.medic');
+    var medic = require('org.apache.cordova.test-framework.medic');
 
     if (medic.enabled) {
         jasmineRequire.medic(jasmineInterface.jasmine);

--- a/www/main.js
+++ b/www/main.js
@@ -110,7 +110,7 @@ exports.wrapConsole = function() {
   }
 
   function createCustomLogger(type) {
-    var medic = require('cordova-plugin-test-framework.medic');
+    var medic = require('org.apache.cordova.test-framework.medic');
     return function() {
       origConsole[type].apply(origConsole, arguments);
       // TODO: encode log type somehow for medic logs?
@@ -228,7 +228,7 @@ function updateEnabledTestCount() {
   var enabledLabel = document.getElementById('tests-enabled');
 
   // Determine how many tests are currently enabled
-  var cdvtests = cordova.require('cordova-plugin-test-framework.cdvtests');
+  var cdvtests = cordova.require('org.apache.cordova.test-framework.cdvtests');
   var total = 0;
   var enabled = 0;
   iterateAutoTests(cdvtests, function(api, testModule) {
@@ -311,7 +311,7 @@ function toggleTestHandler(event) {
 /******************************************************************************/
 
 function toggleTestEnabled(checkbox) {
-  var cdvtests = cordova.require('cordova-plugin-test-framework.cdvtests');
+  var cdvtests = cordova.require('org.apache.cordova.test-framework.cdvtests');
   cdvtests.tests[checkbox.value].setEnabled(checkbox.checked);
 }
 
@@ -336,7 +336,7 @@ function runAutoTests() {
   createActionButton('Reset App', location.reload.bind(location));
   createActionButton('Back', setMode.bind(null, 'main'));
 
-  var cdvtests = cordova.require('cordova-plugin-test-framework.cdvtests');
+  var cdvtests = cordova.require('org.apache.cordova.test-framework.cdvtests');
   cdvtests.init();
   setupAutoTestsEnablers(cdvtests);
 
@@ -363,7 +363,7 @@ function runManualTests() {
     createActionButton('Reset App', location.reload.bind(location));
     createActionButton('Back', setMode.bind(null, 'manual'));
   };
-  var cdvtests = cordova.require('cordova-plugin-test-framework.cdvtests');
+  var cdvtests = cordova.require('org.apache.cordova.test-framework.cdvtests');
   cdvtests.defineManualTests(contentEl, beforeEach, createActionButton);
 }
 
@@ -400,7 +400,7 @@ exports.init = function() {
   attachEvents();
   exports.wrapConsole();
 
-  var medic = require('cordova-plugin-test-framework.medic');
+  var medic = require('org.apache.cordova.test-framework.medic');
   medic.load(function() {
     if (medic.enabled) {
       setMode('auto');

--- a/www/tests.js
+++ b/www/tests.js
@@ -79,7 +79,7 @@ function requireAllTestModules() {
 }
 
 function createJasmineInterface() {
-  var jasmine_helpers = require('cordova-plugin-test-framework.jasmine_helpers');
+  var jasmine_helpers = require('org.apache.cordova.test-framework.jasmine_helpers');
   var jasmineInterface = jasmine_helpers.setUpJasmine();
   return jasmineInterface;
 }


### PR DESCRIPTION
This reverts commit 79b0c695515151217b9b791cd2bda75a41f87c2f.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
