### PR TITLE
chore: use short notation in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,8 @@
     "id": "cordova-plugin-test-framework",
     "platforms": []
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/apache/cordova-plugin-test-framework"
-  },
-  "bugs": {
-    "url": "https://issues.apache.org/jira/browse/CB"
-  },
+  "repository": "github:apache/cordova-plugin-test-framework",
+  "bugs": "https://github.com/apache/cordova-plugin-test-framework/issues",
   "keywords": [
     "cordova",
     "test",


### PR DESCRIPTION
### Motivation, Context & Description

- Cleanup the repo and bug information in the `package.json` file.
- Uses short notation.

### Testing

- N/A
