### PR TITLE
(android) allow insecure requests for test results communication

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -43,4 +43,13 @@
             <preference name="hostname" value="localhost" />
         </config-file>
     </platform>
+
+    <platform name="android">
+        <config-file target="config.xml" parent="/*">
+            <preference name="AndroidInsecureFileModeEnabled" value="true" />
+        </config-file>
+        <edit-config xmlns:android="http://schemas.android.com/apk/res/android" file="AndroidManifest.xml" mode="merge" target="/manifest/application">
+            <application android:usesCleartextTraffic="true" />
+        </edit-config>
+    </platform>
 </plugin>


### PR DESCRIPTION
### Platforms affected
- android


### Motivation and Context
Allowing insecure (HTTP) is necessary for `cordova-paramedic` to work, because the `cordova-plugin-test-framework` scripts running in the cordova environment, need to post (HTTP PUT) test results to the local server of `cordova-paramedic`, awaiting the results.

To address the need for insecure (HTTP) is why `plugin.xml` is updated to enable both `AndroidInsecureFileModeEnabled=true` and `android:usesCleartextTraffic=true`.


### Description
Updated configuration in `plugin.xml` of this project to allow android to make insecure (HTTP) requests.


### Testing
This is a little bit roundabout because of having `cordova-paramedic` in the loop. Let me know if there is a better test.

- Tested by updating my copy of [`cordova-paramedic`](https://github.com/apache/cordova-paramedic) to reference this patched version of `cordova-plugin-test-framework` this commit 973f131
  - Prior to the patch, running `cordova-paramedic --platform android@10.1.0 --plugin cordova-plugin-statusbar` would hang, on the step: **"cordova-paramedic: waiting for test results"**
  - Patched now succeeds and will output test results.
- Here is a [GitHub Actions run](https://github.com/SwitchCaseGroup/cordova-plugin-statusbar/runs/3446507483) of `cordova-plugin-statusbar` against this patched version of cordova paramedic
  - The important bit is in CI.yml `npm install -g SwitchCaseGroup/cordova-paramedic#ec0a7e0` where the patched `cordova-paramedic` is referencing this
```diff
diff --git a/lib/ParamedicApp.js b/lib/ParamedicApp.js
index 7f70920..c52706b 100644
--- a/lib/ParamedicApp.js
+++ b/lib/ParamedicApp.js
@@ -68,7 +68,7 @@ class ParamedicApp {
         pluginsManager.installPlugins(this.config.getPlugins());
         pluginsManager.installTestsForExistingPlugins();
 
-        let additionalPlugins = ['github:apache/cordova-plugin-test-framework', path.join(__dirname, '..', 'paramedic-plugin')];
+        let additionalPlugins = ['github:SwitchCaseGroup/cordova-plugin-test-framework#allow-http-for-posting-status', path.join(__dirname, '..', 'paramedic-plugin')];
 
         if (this.config.shouldUseSauce() && !this.config.getUseTunnel()) {
             additionalPlugins.push(path.join(__dirname, '..', 'event-cache-plugin'));
```

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
