### PR TITLE
fix(browser): align test page with Jasmine 5 and remove missing asset refs

### DIFF
--- a/www/assets/index.html
+++ b/www/assets/index.html
@@ -23,10 +23,11 @@
     <head>
         <!--
         Inject CSP
-
-        If not hosted in mobilespec, the injection script will likely not
-        exist.  It would be up to the hosting app to provide the named
-        script to setup CSP as desired.
+        csp-incl.js will only be injected by cordova-mobile-spec, see:
+        https://github.com/apache/cordova-mobile-spec/blob/master/www/csp-incl.js
+        If not hosted in cordova-mobile-spec, the injection script will
+        likely not exist and produce a 404. It would be up to the hosting
+        app to provide the named script to setup CSP as desired.
         -->
         <script type="text/javascript" src="../csp-incl.js"></script>
 

--- a/www/assets/index.html
+++ b/www/assets/index.html
@@ -41,6 +41,15 @@
 
         <script type="text/javascript" src="jasmine/jasmine.js"></script>
         <script type="text/javascript" src="jasmine/jasmine-html.js"></script>
+        <!--
+        In Jasmine 3.10.0 and newer versions, the classic boot.js was
+        split into two files: boot0.js and boot1.js.
+        boot0.js is the first file loaded in a standalone Jasmine test environment,
+        responsible for creating the execution environment and exposing the global testing functions.
+        boot1.js is intentionally not loaded. If boot1.js were included, it would auto-run specs on
+        window load. But this project waits for Cordova setup and then runs tests manually via
+        Jasmine env execute in www/main.js, after app init flow from www/assets/main-bootstrap.js.
+        -->
         <script type="text/javascript" src="jasmine/boot0.js"></script>
         <script type="text/javascript" src="jasmine-medic.js"></script>
 

--- a/www/assets/index.html
+++ b/www/assets/index.html
@@ -21,6 +21,15 @@
 -->
 <html>
     <head>
+        <!--
+        Inject CSP
+
+        If not hosted in mobilespec, the injection script will likely not
+        exist.  It would be up to the hosting app to provide the named
+        script to setup CSP as desired.
+        -->
+        <script type="text/javascript" src="../csp-incl.js"></script>
+
         <title>Cordova tests</title>
         <meta charset="utf-8" />
         <meta name="format-detection" content="telephone=no" />

--- a/www/assets/index.html
+++ b/www/assets/index.html
@@ -35,14 +35,12 @@
         <meta name="format-detection" content="telephone=no" />
         <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width" />
 
-        <link rel="stylesheet" type="text/css" href="bootstrap/bootstrap.min.css">
-
         <link rel="stylesheet" type="text/css" href="jasmine/jasmine.css" media="screen">
         <link rel="stylesheet" type="text/css" href="main.css" media="screen">
 
-        <script type="text/javascript" src="bootstrap/bootstrap.bundle.min.js"></script>
         <script type="text/javascript" src="jasmine/jasmine.js"></script>
         <script type="text/javascript" src="jasmine/jasmine-html.js"></script>
+        <script type="text/javascript" src="jasmine/boot0.js"></script>
         <script type="text/javascript" src="jasmine-medic.js"></script>
 
         <script type="text/javascript" src="../cordova.js"></script>

--- a/www/assets/index.html
+++ b/www/assets/index.html
@@ -21,15 +21,6 @@
 -->
 <html>
     <head>
-        <!--
-        Inject CSP
-
-        If not hosted in mobilespec, the injection script will likely not
-        exist.  It would be up to the hosting app to provide the named
-        script to setup CSP as desired.
-        -->
-        <script type="text/javascript" src="../csp-incl.js"></script>
-
         <title>Cordova tests</title>
         <meta charset="utf-8" />
         <meta name="format-detection" content="telephone=no" />


### PR DESCRIPTION
## Summary
This PR updates browser test assets to match the current Jasmine runtime and reduce CI noise.

### Changes
- Load `jasmine/boot0.js` in `www/assets/index.html` so Jasmine 5 initializes the global interface expected by the test harness.
- Remove stale Bootstrap CSS/JS references from `www/assets/index.html` that are not shipped in plugin assets and produced 404s.
- Improve documentation for injecting `csp-incl.js`
  - Make clear, that this is only injected by `cordova-mobile-spec` and will produce a 404 when not hosted in `cordova-mobile-spec`.
  - Add link for `csp-incl.js` of `cordova-mobile-spec`

## Motivation
Without bootstrapping, harness code calling `window.jasmine.getEnv()` may fail under Jasmine 5. Missing static references also clutter CI output and obscure actionable failures.

## Validation
- Browser tests execute and report successfully in plugin CI using this asset page.
- Removed references are cosmetic/non-runtime dependencies and do not affect test execution.

## Cross-PR Testing Note
For integration testing purposes, apache/cordova-paramedic#302 installs this PR via `apache/cordova-plugin-test-framework#pull/69/head`.

## Downstream Validation
A dedicated downstream test PR is open in `apache/cordova-plugin-network-information`:
- https://github.com/apache/cordova-plugin-network-information/pull/184

That PR consumes this change chain and demonstrates successful CI runs.

Generated-By: GPT-5.3-Codex
